### PR TITLE
Widget Horizontal Scroll View #6

### DIFF
--- a/lib/ui/horizontal_trupp_view.dart
+++ b/lib/ui/horizontal_trupp_view.dart
@@ -96,10 +96,10 @@ class _HorizontalTruppViewState extends State<HorizontalTruppView> {
                   ? Center(
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
-                        children: const [
-                          Icon(Icons.add, size: 48, color: Colors.black54),
-                          SizedBox(height: 8),
-                          Text('Neuer Trupp', style: TextStyle(fontSize: 18)),
+                        children: [
+                          const Icon(Icons.add, size: 48, color: Colors.black54),
+                          const SizedBox(height: 8),
+                          const Text('Neuer Trupp', style: TextStyle(fontSize: 18)),
                         ],
                       ),
                     )


### PR DESCRIPTION
Created Flutter widget, as specified in #6.
`HorizontalTruppView` provides a horizontally scrollable, paged view for displaying "Trupp" pages, with an integrated "New Trupp" tile for creating additional entries. 

Changes: 
- Added the `HorizontalTruppView` widget in `lib/ui/horizontal_trupp_view.dart`.
- Implemented a horizontally scrollable `PageView` with custom viewport fraction, ensuring multiple trupps are visible at once and a consistent layout.
- Included logic for the "New Trupp" tile to trigger a callback (`onCreateNew`) when tapped, enabling parent widgets to handle creation actions.
- Provided a clean and modular `_buildPageItem` method for rendering each page and the creation tile, supporting future design changes.

![iScreen Shoter - qemu-system-aarch64 - 251024173345](https://github.com/user-attachments/assets/cacf0671-11ad-4442-a49a-ba1ad648a1ee)