### PR TITLE
add error handling to auth processes

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -37,5 +37,7 @@ linter:
     no_leading_underscores_for_local_identifiers: true
     prefer_relative_imports: true
     implementation_imports: true
+    unnecessary_breaks: true
+    use_build_context_synchronously: true
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/lib/firebase/firebase_auth_service.dart
+++ b/lib/firebase/firebase_auth_service.dart
@@ -3,21 +3,67 @@ import 'package:firebase_auth/firebase_auth.dart';
 class FirebaseAuthService {
   final FirebaseAuth _auth = FirebaseAuth.instance;
 
-  //Registration
-  Future<UserCredential>
-  signUpWithEmailAndPassword(
-    String email, String password) async {
-      return await _auth.createUserWithEmailAndPassword(email: email, password: password);
+  static String errorMessageFromException(
+    FirebaseAuthException e,
+    bool isLogin, {
+    bool? withDetails,
+  }) {
+    withDetails ??= !isLogin;
+    final generalMessage = isLogin
+        ? 'Ungültige Anmeldeinformationen. Bitte überprüfen Sie Ihre Eingaben und versuchen Sie es erneut.'
+        : 'Ein Fehler ist aufgetreten. Bitte versuchen Sie es später erneut.';
+    switch (e.code) {
+      case 'network-request-failed':
+        return 'Keine Internetverbindung. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.';
+      case 'too-many-requests':
+        return 'Zu viele Anmeldeversuche. Bitte versuchen Sie es später erneut.';
+      case 'operation-not-allowed':
+        throw StateError('Email/Password Sign-In ist nicht aktiviert.');
+      case 'email-already-in-use':
+        if (withDetails) {
+          return 'Konnte kein Konto erstellen, bitte verwenden Sie eine andere Email-Adresse.';
+        } else {
+          return generalMessage;
+        }
+      case 'invalid-email':
+        if (withDetails) {
+          return 'Die eingegebene Email ist ungültig.';
+        } else {
+          return generalMessage;
+        }
+      case 'weak-password':
+        if (withDetails) {
+          return 'Das eingegebene Passwort ist zu schwach. Bitte wählen Sie ein stärkeres Passwort.';
+        } else {
+          return generalMessage;
+        }
+      // intentional catch-all for multiple error codes as to not give too much information
+      default:
+        return generalMessage;
     }
-  
+  }
+
+  //Registration
+  Future<UserCredential> signUpWithEmailAndPassword(
+    String email,
+    String password,
+  ) async {
+    return await _auth.createUserWithEmailAndPassword(
+      email: email,
+      password: password,
+    );
+  }
 
   //Login
-  Future<UserCredential>
-  signInWithEmailAndPassword(
-    String email, String password) async {
-      return await _auth.signInWithEmailAndPassword(email: email, password: password);
-    }
-  
+  Future<UserCredential> signInWithEmailAndPassword(
+    String email,
+    String password,
+  ) async {
+    return await _auth.signInWithEmailAndPassword(
+      email: email,
+      password: password,
+    );
+  }
 
   //Logout
   Future<void> signOut() async {

--- a/lib/ui/auth/post_register.dart
+++ b/lib/ui/auth/post_register.dart
@@ -14,27 +14,37 @@ class PostRegisterScreen extends ConsumerWidget {
     return AuthScaffold(
       body: Center(
         child: InitialSettingsForm(
-              onSubmit: (pressure, duration) async {
-                // Ensure repository is available before saving
-                final repository = ref.read(initialSettingsRepositoryProvider);
-                if (repository == null) {
-                  // Should not happen since user just registered, but guard anyway
-                  if (!context.mounted) return;
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Fehler: Authentifizierung fehlgeschlagen'),
-                    ),
-                  );
-                  return;
-                }
-                await repository.save(
-                  defaultPressure: pressure,
-                  theoreticalDurationMinutes: duration.inMinutes,
-                );
-                if (!context.mounted) return;
-                context.goNamed('operation');
-              },
-            ),
+          onSubmit: (pressure, duration) async {
+            // Ensure repository is available before saving
+            final repository = ref.read(initialSettingsRepositoryProvider);
+            if (repository == null) {
+              // Should not happen since user just registered, but guard anyway
+              if (!context.mounted) return;
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Fehler: Authentifizierung fehlgeschlagen'),
+                ),
+              );
+              return;
+            }
+            try {
+              await repository.save(
+                defaultPressure: pressure,
+                theoreticalDurationMinutes: duration.inMinutes,
+              );
+            } catch (e) {
+              if (!context.mounted) return;
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text('Fehler beim Speichern der Einstellungen: $e'),
+                ),
+              );
+              return;
+            }
+            if (!context.mounted) return;
+            context.goNamed('operation');
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
Add error handling to auth processes. If there is an error a message according to the type is displayed. Some messages are intentionally vague to not give away too much information.

Also introduces two new analyzer rules to avoid confusions as they happened in development of this PR.