### PR TITLE
fix: added case-insensitive duplicate check for firefighters and radio call

### DIFF
--- a/lib/ui/core/person_selector.dart
+++ b/lib/ui/core/person_selector.dart
@@ -33,6 +33,22 @@ class PersonSelector extends ConsumerWidget {
     if (trimmed.isEmpty) return;
     final normalized = trimmed.toLowerCase();
 
+    final existingName = firefightersList
+        .map((f) => f.name)
+        .firstWhere(
+          (name) => name.toLowerCase() == normalized,
+          orElse: () => '',
+        );
+
+    if (existingName.isNotEmpty && existingName != trimmed) {
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Dieser Name ist bereits vorhanden'),
+        ),
+      );
+      return;
+    }
+
     // blocks reusing a name in any trupp
     final nameUsed = ref.read(einsatzProvider).trupps.values.any((t) {
       String? leader;
@@ -61,7 +77,7 @@ class PersonSelector extends ConsumerWidget {
     }
 
     // Add to repository if the name is new
-    if (!firefightersList.any((f) => f.name == trimmed)) {
+    if (existingName.isEmpty) {
       try {
         final repository = ref.read(firefightersRepositoryProvider);
         if (repository != null) {
@@ -76,10 +92,15 @@ class PersonSelector extends ConsumerWidget {
       }
     }
     if (context.mounted) {
+      final selectedName = existingName.isEmpty ? trimmed : existingName;
       if (index == 0) {
-        ref.read(einsatzProvider.notifier).setLeaderName(truppNumber, trimmed);
+        ref
+            .read(einsatzProvider.notifier)
+            .setLeaderName(truppNumber, selectedName);
       } else {
-        ref.read(einsatzProvider.notifier).setMemberName(truppNumber, trimmed);
+        ref
+            .read(einsatzProvider.notifier)
+            .setMemberName(truppNumber, selectedName);
       }
     }
   }


### PR DESCRIPTION
This pull request enhances the handling of name and radio call inputs in the files `PersonSelector.dart` and `WidgetNewTrupp.dart`, as suggested in #72. 

### Duplicate Prevention and Normalization Improvements
- Added case-insensitive duplicate checks when adding new firefighter names or radio calls, showing a snackbar if a duplicate (with different casing) exists and preventing the addition.

### Consistent Data Usage and Repository Updates
- Modified repository update conditions to use the results of the new duplicate checks, ensuring only truly new (case-insensitive) names and radio calls are added. 
- Ensured that when selecting a name or radio call, the existing value is used rather than the new user input, maintaining consistency in stored data. 