### PR TITLE
fix: "Druck speichern" - Button now closes the Bottom Sheet

### DIFF
--- a/lib/ui/trupp/end.dart
+++ b/lib/ui/trupp/end.dart
@@ -58,10 +58,12 @@ class End extends StatelessWidget {
                   showModalBottomSheet(
                     context: context,
                     isScrollControlled: true,
-                    builder: (context) {
+                    builder: (bottomSheetContext) {
                       return Pressure(
                         onPressureSelected: (leaderPressure, memberPressure) {
                           onPressureSelected(leaderPressure, memberPressure);
+
+                          Navigator.of(bottomSheetContext).pop();
                         },
                         lowestPressure: lowestPressure,
                       );


### PR DESCRIPTION
This PR implements a fix which ensures the "Druck speichern" - Button closes the dialogue. Closes #85.