### PR TITLE
fix: alarms sounding even when out of sight and sound ack only ack one alarm

### DIFF
--- a/lib/ui/app.dart
+++ b/lib/ui/app.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../router/router.dart';
+import '../audioplayers/sound_service.dart';
+import '../model/einsatz/einsatz.dart';
 
 class AsuApp extends ConsumerWidget {
   const AsuApp({super.key});
@@ -9,6 +11,25 @@ class AsuApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(goRouterProvider);
+
+    ref.listen(
+      einsatzProvider.select((e) {
+        int count = 0;
+        for (final alarmList in e.alarms.values) {
+          count += alarmList.where((a) => a.type == AlarmType.sound).length;
+        }
+        return count;
+      }),
+      (previous, current) async {
+        final soundService = SoundService();
+        if (current > 0 && (previous == null || previous == 0)) {
+          await soundService.playAlarmSound();
+        } else if (current == 0 && previous != null && previous > 0) {
+          await soundService.stopAlarmSound();
+        }
+      }
+    );
+
     return OrientationBuilder(
       builder: (context, orientation) {
         if (orientation == Orientation.portrait) {

--- a/lib/ui/trupp/alarm_view.dart
+++ b/lib/ui/trupp/alarm_view.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../audioplayers/sound_service.dart';
 import '../../model/einsatz/einsatz.dart';
 
 class AlarmView extends ConsumerWidget {
@@ -28,13 +27,6 @@ class AlarmView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     if (alarms.isEmpty) return const SizedBox.shrink();
-
-    final soundService = SoundService();
-
-    final hasSoundingAlarm = alarms.any((a) => a.type == AlarmType.sound);
-    if (hasSoundingAlarm) {
-      soundService.playAlarmSound();
-    }
 
     return Center(
       child: Container(
@@ -70,7 +62,6 @@ class AlarmView extends ConsumerWidget {
             const SizedBox(height: 24),
             ElevatedButton.icon(
               onPressed: () async {
-                await soundService.stopAlarmSound();
                 for (var alarm in alarms) {
                   ref
                       .read(einsatzProvider.notifier)

--- a/lib/ui/trupp/trupp.dart
+++ b/lib/ui/trupp/trupp.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
-import '../../audioplayers/sound_service.dart';
 import '../../model/trupp/trupp.dart';
 import 'alarm_view.dart';
 import 'end_handler.dart';
@@ -64,27 +63,6 @@ class Trupp extends ConsumerWidget {
     // Alarms
     final alarms = ref.watch(
       einsatzProvider.select((e) => e.alarms[truppNumber] ?? []),
-    );
-
-    // Listen to sound alarms - handle both start and stop
-    ref.listen(
-      einsatzProvider.select((e) {
-        final alarms = e.alarms[truppNumber] ?? [];
-        return alarms.any((a) => a.type == AlarmType.sound);
-      }),
-      (previous, current) {
-        final soundService = SoundService();
-
-        // Start sound when sound alarm appears
-        if (previous == false && current == true) {
-          soundService.playAlarmSound();
-        }
-
-        // Stop sound when all sound alarms are cleared
-        if (previous == true && current == false) {
-          soundService.stopAlarmSound();
-        }
-      },
     );
 
     final popUpAlarms = alarms
@@ -422,8 +400,6 @@ class OperationInfo extends ConsumerWidget {
               const SizedBox(width: 8),
               ElevatedButton.icon(
                 onPressed: () async {
-                  final soundService = SoundService();
-                  await soundService.stopAlarmSound();
                   ref
                       .read(einsatzProvider.notifier)
                       .ackSoundingAlarm(truppNumber, AlarmReason.checkPressure);


### PR DESCRIPTION
Closes #97 and #96 

The sound logic was moved to app.dart to be available at every view. Alarm sound is now playing even when the visual alarm is not in user's sight. When sound alarms are acknowledged and an other sound alarms are active, the sound continues to play.